### PR TITLE
:sparkles: URL が<>で囲まれていても検索できるようにします

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,7 +22,9 @@ let idb = new irasutoya.IrasutoyaDb();
 let bot = new builder.UniversalBot(connector, async function (session) {
     try {
         session.send("%s を受け取ったよ", session.message.text);
-        let tags = await getImageTags_1.getImageTags(session.message.text);
+        // Slackから受け取ったメッセージはURLが<>で囲まれるためトリミングを行います
+        let url = session.message.text.replace(/(^<)|(>$)/g, "");
+        let tags = await getImageTags_1.getImageTags(url);
         let result = await Promise.all(tags.slice(0, 3).map(async (word) => {
             let wordJa = await transrator_1.translate.translateGo(word);
             return idb.query(wordJa).slice(0, 2).map((r) => [wordJa, r]);

--- a/app.ts
+++ b/app.ts
@@ -25,7 +25,9 @@ let idb = new irasutoya.IrasutoyaDb();
 let bot = new builder.UniversalBot(connector, async function(session) {
     try {
         session.send("%s を受け取ったよ", session.message.text)
-        let tags = await getImageTags(session.message.text);
+        // Slackから受け取ったメッセージはURLが<>で囲まれるためトリミングを行います
+        let url = session.message.text.replace(/(^<)|(>$)/g, "")
+        let tags = await getImageTags(url);
         let result = await Promise.all(tags.slice(0, 3).map(async (word) => {
             let wordJa = await translate.translateGo(word);
             return idb.query(wordJa).slice(0, 2).map((r) => [wordJa, r]);


### PR DESCRIPTION
受け取ったメッセージの先頭の<と最後尾の>をするようにします

Slack から受け取ったメッセージでは URL が<>で囲まれています。
これは Slack の仕様のようです。
正規表現などで URL をマッチングするのが好ましいとは思いますが
暫定対応のために<>を削除する実装を入れます